### PR TITLE
lowercase job name

### DIFF
--- a/deploy_to_kubernetes_cron.sh
+++ b/deploy_to_kubernetes_cron.sh
@@ -21,7 +21,7 @@ for command in "${!commands[@]}"; do
 
   export COMMAND="[${formatted_command}]"
   export SCHEDULE="${commands[$command]}"
-  export NAME="${NAME}"
+  export NAME=$(echo $NAME | awk '{print tolower($0)}')
 
 
   echo COMMAND "$COMMAND"


### PR DESCRIPTION
### Purpose
`* metadata.name: Invalid value: "fetch-raw-facebook-rawEntities": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`
Need a lowercase name