### PR TITLE
delete job on deploy

### DIFF
--- a/deploy_to_kubernetes_cron.sh
+++ b/deploy_to_kubernetes_cron.sh
@@ -8,6 +8,7 @@ source /deploy/kubernetes_deploy_base.sh
 JOB_NAME=$NAME
 
 /deploy/kubernetes_deploy_base.sh
+
 export PRIMARY_IMAGE="${PRIMARY_IMAGE}"
 
 for command in "${!commands[@]}"; do
@@ -23,11 +24,12 @@ for command in "${!commands[@]}"; do
   export SCHEDULE="${commands[$command]}"
   export NAME="${NAME}"
 
-
   echo COMMAND "$COMMAND"
   echo NAME "$NAME"
   echo SCHEDULE "$SCHEDULE"
   echo PRIMARY_IMAGE "$PRIMARY_IMAGE"
+
+  kubectl delete cronjob $NAME
 
   /deploy/templater.sh ${JOB_TEMPLATE} > ${JOB_FILE}
   kubectl apply --record -f ${JOB_FILE}


### PR DESCRIPTION
##### Purpose
Applying new config to existing cronjob templates do not update the image that the cronjob uses. Sending delete before applying the template so the image being used is the current one.