### PR TITLE
Fix job name for fetch jobs

### DIFF
--- a/deploy_to_kubernetes_cron.sh
+++ b/deploy_to_kubernetes_cron.sh
@@ -18,7 +18,7 @@ for command in "${!commands[@]}"; do
   # Split string into array of strings
   split_command=($command)
 
-  # Last item in command will be the name, cannot include slashes.
+  # Name will include last item of command, cannot include slashes.
   NAME="$NAME-${split_command[-1]}"
 
   export COMMAND="[${command}]"

--- a/deploy_to_kubernetes_cron.sh
+++ b/deploy_to_kubernetes_cron.sh
@@ -18,7 +18,7 @@ for command in "${!commands[@]}"; do
   command_strings=($command)
 
   # Start comma seperated values with first value
-  command_csv=\"${command_strings[0]}\"
+  command_csv="${command_strings[0]}"
   for i in "${split_command[@]:1}"; do
     # Append new values with comma
     command_csv="${command_csv}, \"${i}\""

--- a/deploy_to_kubernetes_cron.sh
+++ b/deploy_to_kubernetes_cron.sh
@@ -19,7 +19,9 @@ for command in "${!commands[@]}"; do
 
   # Start comma seperated values with first value.
   command_csv="${command_strings[0]}"
-  for i in "${split_command[@]:1}"; do
+
+  # `:1` -- Start loop at second value.
+  for i in "${command_strings[@]:1}"; do
     # Append new values with comma.
     command_csv="${command_csv}, \"${i}\""
   done

--- a/deploy_to_kubernetes_cron.sh
+++ b/deploy_to_kubernetes_cron.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-# NAME, commands
+# NAME, `commands`
 source /deploy/kubernetes/commands.sh && get_commands
 source /deploy/kubernetes_deploy_base.sh
 
@@ -17,10 +17,10 @@ for command in "${!commands[@]}"; do
   # Split string into array of strings
   command_strings=($command)
 
-  # Start comma seperated values with first value
+  # Start comma seperated values with first value.
   command_csv="${command_strings[0]}"
   for i in "${split_command[@]:1}"; do
-    # Append new values with comma
+    # Append new values with comma.
     command_csv="${command_csv}, \"${i}\""
   done
 

--- a/deploy_to_kubernetes_cron.sh
+++ b/deploy_to_kubernetes_cron.sh
@@ -5,7 +5,7 @@ source /deploy/kubernetes/commands.sh && get_commands
 source /deploy/kubernetes_deploy_base.sh
 
 JOB_TEMPLATE="/deploy/kubernetes/cron.job.template.yaml"
-TEMPORARY_JOB_FILE="/deploy/kubernetes/cron.job.yaml"
+TEMPORARY_JOB_FILE="/deploy/kubernetes/cron.job.temporary.yaml"
 
 # PRIMARY_IMAGE
 /deploy/kubernetes_deploy_base.sh
@@ -14,14 +14,20 @@ TEMPORARY_JOB_FILE="/deploy/kubernetes/cron.job.yaml"
 
 # Get all keys, each as a new string: "${!commands[@]}" 
 for command in "${!commands[@]}"; do
-
   # Split string into array of strings
-  split_command=($command)
+  command_strings=($command)
+
+  # Start comma seperated values with first value
+  command_csv=\"${command_strings[0]}\"
+  for i in "${split_command[@]:1}"; do
+    # Append new values with comma
+    command_csv="${command_csv}, \"${i}\""
+  done
 
   # Name will include last item of command, cannot include slashes.
-  NAME="$NAME-${split_command[-1]}"
+  NAME="$NAME-${command_strings[-1]}"
 
-  export COMMAND="[${command}]"
+  export COMMAND="[${command_csv}]"
   export SCHEDULE="${commands[$command]}"
   export NAME=$(echo $NAME | awk '{print tolower($0)}')
 


### PR DESCRIPTION
#### Purpose
My nodejs command now has a memory argument.
`/usr/local/bin/node --max-old-space-size=8192 /app/src/runners rawMetrics`

This causes the name to become `/app/src/runners`.

I'm changing this script to set the last word to the name rather than word 2.

#### Notes
Left some bash explainers, cleaned up the code a bit, tested locally.