### PR TITLE
anchor name ref to variable in cron deploy

### DIFF
--- a/deploy_to_kubernetes_cron.sh
+++ b/deploy_to_kubernetes_cron.sh
@@ -4,6 +4,7 @@
 source /deploy/kubernetes/commands.sh && get_commands
 source /deploy/kubernetes_deploy_base.sh
 
+JOB_NAME=$NAME
 JOB_TEMPLATE="/deploy/kubernetes/cron.job.template.yaml"
 TEMPORARY_JOB_FILE="/deploy/kubernetes/cron.job.temporary.yaml"
 
@@ -27,7 +28,7 @@ for command in "${!commands[@]}"; do
   done
 
   # Name will include last item of command, cannot include slashes.
-  NAME="$NAME-${command_strings[-1]}"
+  NAME="$JOB_NAME-${command_strings[-1]}"
 
   export COMMAND="[${command_csv}]"
   export SCHEDULE="${commands[$command]}"


### PR DESCRIPTION
NAME is being saved to on every loop, so the second job name would be `fetch-raw-facebook-rawentities-rawmetrics`

Setting the name to a variable that won't get modified.